### PR TITLE
Add options when fetching all transactions on an account.

### DIFF
--- a/lib/monzo/transaction.rb
+++ b/lib/monzo/transaction.rb
@@ -58,8 +58,9 @@ module Monzo
     # account_id - The account id to retrieve transactions from.
     #
     # Returns an Array of Monzo::Transaction.
-    def self.all(account_id)
-      response = Monzo.client.get("/transactions", :account_id => account_id)
+    def self.all(account_id, options = {})
+      options[:account_id] = account_id
+      response = Monzo.client.get("/transactions", options)
       parsed_response = JSON.parse(response.body, :symbolize_names => true)
 
       parsed_response[:transactions].map do |item|

--- a/lib/monzo/version.rb
+++ b/lib/monzo/version.rb
@@ -1,4 +1,4 @@
 module Monzo
   # Public: The version number of the gem.
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,6 +2,6 @@ require "spec_helper"
 
 describe Monzo do
   it "has a version number" do
-    expect(Monzo::VERSION).to eql("0.1.0")
+    expect(Monzo::VERSION).to eql("0.1.1")
   end
 end


### PR DESCRIPTION
Hi Murray. Thanks for the gem. I've raised this tiny PR to add the ability to get all of the merchant details for all of the transactions in one go, like this:
`Monzo::Transaction.all('acc_xxxxxxxxxxxxx', {'expand[]': 'merchant'})`
Thanks,
Andrew.